### PR TITLE
Support adapter scaling to all replicas

### DIFF
--- a/pkg/controller/modeladapter/modeladapter_controller.go
+++ b/pkg/controller/modeladapter/modeladapter_controller.go
@@ -343,72 +343,41 @@ func (r *ModelAdapterReconciler) DoReconcile(ctx context.Context, req ctrl.Reque
 
 	oldInstance := instance.DeepCopy()
 
-	// Step 1: Schedule Pod for ModelAdapter
-	selectedPod := &corev1.Pod{}
-	existPods := false
-	var err error
-	if instance.Status.Instances != nil && len(instance.Status.Instances) != 0 {
-		// model adapter has already been scheduled to some pods
-		// check the scheduled pod first, verify the mapping is still valid.
-		// TODO: this needs to be changed once we support multiple lora adapters
-		selectedPodName := instance.Status.Instances[0]
-		if err := r.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: selectedPodName}, selectedPod); err != nil && apierrors.IsNotFound(err) {
-			klog.ErrorS(err, "Selected pod has been deleted and it should be removed from model adapter instance list", "modelAdapter", klog.KObj(instance))
-			// instance.Status.Instances has been outdated, and we need to clear the pod list
-			// after the pod list is cleaned up, let's reconcile the instance object again in the next loop
-			return ctrl.Result{}, r.clearModelAdapterInstanceList(ctx, instance, selectedPodName)
-		} else if err != nil {
-			// failed to fetch the pod, let's requeue
-			return ctrl.Result{RequeueAfter: defaultRequeueDuration}, err
-		} else {
-			// compare instance and model adapter labels.
-			selector, err := metav1.LabelSelectorAsSelector(instance.Spec.PodSelector)
-			if err != nil {
-				// TODO: this should barely happen, let's move this logic to earlier validation logics.
-				return ctrl.Result{}, fmt.Errorf("failed to convert pod selector: %v", err)
-			}
-			if !selector.Matches(labels.Set(selectedPod.Labels)) {
-				klog.Warning("current assigned pod selector doesn't match model adapter selector")
-				return ctrl.Result{}, r.clearModelAdapterInstanceList(ctx, instance, selectedPodName)
-			}
+	// Step 1: Sync Pod instances for ModelAdapter
+	activePods, err := r.getActivePodsForModelAdapter(ctx, instance)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 
-			// base model pod could be unhealthy or in termination, let's clean up the instances.
-			if !utils.IsPodReady(selectedPod) || utils.IsPodTerminating(selectedPod) {
-				klog.Warningf("current assigned pod %s/%s is not ready, remove it and reschedule the adapter", selectedPod.Namespace, selectedPod.Name)
-				return ctrl.Result{}, r.clearModelAdapterInstanceList(ctx, instance, selectedPodName)
-			}
+	activeMap := make(map[string]corev1.Pod, len(activePods))
+	for _, p := range activePods {
+		activeMap[p.Name] = p
+	}
 
-			existPods = true
+	var updatedInstances []string
+	for _, name := range instance.Status.Instances {
+		if _, ok := activeMap[name]; ok {
+			updatedInstances = append(updatedInstances, name)
+		}
+	}
+	instance.Status.Instances = updatedInstances
+
+	added := false
+	for name := range activeMap {
+		if !StringInSlice(instance.Status.Instances, name) {
+			instance.Status.Instances = append(instance.Status.Instances, name)
+			added = true
 		}
 	}
 
-	if !existPods {
-		// TODO: as we plan to support lora replicas, it needs some corresponding changes.
-		// it should return a list of pods in future, otherwise, it should be invoked by N times.
-		activePods, err := r.getActivePodsForModelAdapter(ctx, instance)
-		if err != nil {
+	if added {
+		instance.Status.Phase = modelv1alpha1.ModelAdapterScheduled
+		condition := NewCondition(string(modelv1alpha1.ModelAdapterConditionTypeScheduled), metav1.ConditionTrue,
+			"Scheduled", fmt.Sprintf("ModelAdapter %s has been allocated to pods %v", klog.KObj(instance), instance.Status.Instances))
+		if err := r.updateStatus(ctx, instance, condition); err != nil {
 			return ctrl.Result{}, err
 		}
-		if len(activePods) != 0 {
-			selectedPod, err = r.schedulePod(ctx, instance, activePods)
-			if err != nil {
-				klog.ErrorS(err, "Failed to schedule Pod for ModelAdapter", "modelAdapter", klog.KObj(instance))
-				return ctrl.Result{}, err
-			}
-
-			instance.Status.Phase = modelv1alpha1.ModelAdapterScheduled
-			instance.Status.Instances = append(instance.Status.Instances, selectedPod.Name)
-			condition := NewCondition(string(modelv1alpha1.ModelAdapterConditionTypeScheduled), metav1.ConditionTrue,
-				"Scheduled", fmt.Sprintf("ModelAdapter %s has been allocated to pod %s/%s", klog.KObj(instance), selectedPod.GetNamespace(), selectedPod.GetName()))
-			if err := r.updateStatus(ctx, instance, condition); err != nil {
-				klog.InfoS("Got error when updating status", "error", err, "ModelAdapter", instance)
-				return ctrl.Result{}, err
-			}
-
-			return ctrl.Result{Requeue: true}, nil
-		} else {
-			klog.Warningf("no active pods found for model adapter %v", klog.KObj(instance))
-		}
+		return ctrl.Result{Requeue: true}, nil
 	}
 
 	// Step 2: Reconcile Loading
@@ -558,36 +527,33 @@ func (r *ModelAdapterReconciler) reconcileLoading(ctx context.Context, instance 
 		return nil
 	}
 
-	targetPod := &corev1.Pod{}
-	podName := instance.Status.Instances[0]
-	err := r.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: podName}, targetPod)
-	if err != nil && apierrors.IsNotFound(err) {
-		return fmt.Errorf("pod %s/%s can not be found, skip loading", instance.GetName(), podName)
-	} else if err != nil {
-		return err
-	}
+	for _, podName := range instance.Status.Instances {
+		targetPod := &corev1.Pod{}
+		if err := r.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: podName}, targetPod); err != nil {
+			if apierrors.IsNotFound(err) {
+				return fmt.Errorf("pod %s/%s can not be found, skip loading", instance.GetName(), podName)
+			}
+			return err
+		}
 
-	// selectPod could be in termination, in this case, we just do nothing.
-	if targetPod.DeletionTimestamp != nil {
-		return nil
-	}
+		if targetPod.DeletionTimestamp != nil {
+			continue
+		}
 
-	urls := BuildURLs(targetPod.Status.PodIP, r.RuntimeConfig)
+		urls := BuildURLs(targetPod.Status.PodIP, r.RuntimeConfig)
 
-	// Check if the model is already loaded
-	exists, err := r.modelAdapterExists(urls.ListModelsURL, instance)
-	if err != nil {
-		return err
-	}
-	if exists {
-		klog.V(4).Info("LoRA model has been registered previously, skipping registration")
-		return nil
-	}
+		exists, err := r.modelAdapterExists(urls.ListModelsURL, instance)
+		if err != nil {
+			return err
+		}
+		if exists {
+			klog.V(4).Info("LoRA model has been registered previously, skipping registration")
+			continue
+		}
 
-	// Load the Model adapter
-	err = r.loadModelAdapter(urls.LoadAdapterURL, instance)
-	if err != nil {
-		return err
+		if err := r.loadModelAdapter(urls.LoadAdapterURL, instance); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -703,22 +669,6 @@ func (r *ModelAdapterReconciler) unloadModelAdapter(ctx context.Context, instanc
 		return nil
 	}
 
-	// TODO:(jiaxin.shan) Support multiple instances
-
-	podName := instance.Status.Instances[0]
-	targetPod := &corev1.Pod{}
-	if err := r.Get(ctx, types.NamespacedName{
-		Namespace: instance.Namespace,
-		Name:      podName,
-	}, targetPod); err != nil {
-		if apierrors.IsNotFound(err) {
-			klog.Warningf("Failed to find lora Pod instance %s/%s from apiserver, skip unloading", instance.GetNamespace(), podName)
-			return nil
-		}
-		klog.Warning("Error getting Pod from lora instance list", err)
-		return err
-	}
-
 	payload := map[string]string{
 		"lora_name": instance.Name,
 	}
@@ -727,31 +677,44 @@ func (r *ModelAdapterReconciler) unloadModelAdapter(ctx context.Context, instanc
 		return err
 	}
 
-	urls := BuildURLs(targetPod.Status.PodIP, r.RuntimeConfig)
-	req, err := http.NewRequest("POST", urls.UnloadAdapterURL, bytes.NewBuffer(payloadBytes))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	// Check if "api-key" exists in the map and set the Authorization header accordingly
-	if token, ok := instance.Spec.AdditionalConfig["api-key"]; ok {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
-	}
-
-	httpClient := &http.Client{}
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			klog.InfoS("Error closing response body:", err)
+	for _, podName := range instance.Status.Instances {
+		targetPod := &corev1.Pod{}
+		if err := r.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: podName}, targetPod); err != nil {
+			if apierrors.IsNotFound(err) {
+				klog.Warningf("Failed to find lora Pod instance %s/%s from apiserver, skip unloading", instance.GetNamespace(), podName)
+				continue
+			}
+			klog.Warning("Error getting Pod from lora instance list", err)
+			return err
 		}
-	}()
 
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		body, _ := io.ReadAll(resp.Body)
-		klog.Warningf("failed to unload LoRA adapter: %s", body)
+		urls := BuildURLs(targetPod.Status.PodIP, r.RuntimeConfig)
+		req, err := http.NewRequest("POST", urls.UnloadAdapterURL, bytes.NewBuffer(payloadBytes))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if token, ok := instance.Spec.AdditionalConfig["api-key"]; ok {
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+		}
+
+		httpClient := &http.Client{}
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			continue
+		}
+		func() {
+			defer func() {
+				if err := resp.Body.Close(); err != nil {
+					klog.InfoS("Error closing response body:", err)
+				}
+			}()
+
+			if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+				body, _ := io.ReadAll(resp.Body)
+				klog.Warningf("failed to unload LoRA adapter: %s", body)
+			}
+		}()
 	}
 
 	return nil
@@ -791,166 +754,48 @@ func (r *ModelAdapterReconciler) reconcileService(ctx context.Context, instance 
 	// compare the object difference in future.
 	return ctrl.Result{}, nil
 }
-
 func (r *ModelAdapterReconciler) reconcileEndpointSlice(ctx context.Context, instance *modelv1alpha1.ModelAdapter) (ctrl.Result, error) {
-	// check if the endpoint slice already exists, if not create a new one.
 	found := &discoveryv1.EndpointSlice{}
-	// instance could be clean up in earlier reconciliation, we need to clean up the instance from endpoint list.
-	if len(instance.Status.Instances) == 0 {
-		klog.Warningf("model adapter %s has not been deployed to any pods yet or being deleted, skip creating endpointslice", klog.KObj(instance))
 
-		// reset endpoint slice
-		if err := r.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: instance.Name}, found); err != nil {
-			if apierrors.IsNotFound(err) {
-				klog.Warningf("Failed to fetch the endpoint slice %s", klog.KObj(instance))
+	podList := []corev1.Pod{}
+	for _, podName := range instance.Status.Instances {
+		p := corev1.Pod{}
+		if err := r.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: podName}, &p); err == nil {
+			if p.DeletionTimestamp == nil {
+				podList = append(podList, p)
 			}
-			return ctrl.Result{}, err
 		}
-		found.Endpoints = []discoveryv1.Endpoint{}
-		if err := r.Update(ctx, found); err != nil {
-			klog.ErrorS(err, "Failed to update EndpointSlice after clearing endpoints", "EndpointSlice", found.Name)
-			return ctrl.Result{}, err
-		}
-
-		return ctrl.Result{}, nil
 	}
 
-	// TODO: do necessary refactor to support multiple lora instance
-	podName := instance.Status.Instances[0]
-	pod := &corev1.Pod{}
-	if err := r.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: podName}, pod); err != nil {
+	if err := r.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: instance.Name}, found); err != nil {
 		if !apierrors.IsNotFound(err) {
-			klog.Warning("Error getting Pod from lora instance list", err)
 			return ctrl.Result{}, err
 		}
 
-		klog.Warningf("pod %s/%s has been deleted, let's clean up the endpoint slice", instance.GetNamespace(), podName)
-		// TODO: do necessary refactor to support multiple lora instance
-		// the tricky thing is we do not know the pod map to pod ip mapping. instance only save pods, endpointslice only save ips
-		if err := r.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: instance.Name}, found); err != nil {
-			if apierrors.IsNotFound(err) {
-				// this should barely happen, in this case, there's no need to move forward
-				klog.Warningf("Endpoint slice %s doesn't exist", klog.KObj(instance))
-				return ctrl.Result{}, nil
-			}
-			return ctrl.Result{}, err
+		if len(podList) == 0 {
+			return ctrl.Result{}, nil
 		}
 
-		// reset endpoint slice
-		found.Endpoints = []discoveryv1.Endpoint{}
-		if err := r.Update(ctx, found); err != nil {
-			klog.ErrorS(err, "Failed to update EndpointSlice after clearing endpoints", "EndpointSlice", found.Name)
-			return ctrl.Result{}, err
-		}
-
-		return ctrl.Result{}, nil
-	}
-
-	// pod object fetched, let's check existence of endpoint slice
-	err := r.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: instance.Name}, found)
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			klog.ErrorS(err, "Failed to get EndpointSlice")
-			return ctrl.Result{}, err
-		}
-
-		// EndpointSlice does not exist, create it
-		eps := buildModelAdapterEndpointSlice(instance, pod)
-		// Set the owner reference
+		eps := buildModelAdapterEndpointSlice(instance, podList)
 		if err := ctrl.SetControllerReference(instance, eps, r.Scheme); err != nil {
-			klog.Error(err, "Failed to set controller reference to modelAdapter")
 			return ctrl.Result{}, err
 		}
-
-		// create endpoint slice
-		klog.InfoS("Creating a new EndpointSlice", "endpointslice", klog.KObj(eps))
-		if err = r.Create(ctx, eps); err != nil {
-			klog.ErrorS(err, "Failed to create new EndpointSlice resource for ModelAdapter", "endpointslice", klog.KObj(eps))
-			instance.Status.Phase = modelv1alpha1.ModelAdapterFailed
-			condition := NewCondition(string(modelv1alpha1.ModelAdapterConditionTypeResourceCreated), metav1.ConditionFalse,
-				FailedEndpointSliceCreateReason, fmt.Sprintf("Failed to create EndpointSlice for the custom resource (%s): (%s)", instance.Name, err))
-			if err := r.updateStatus(ctx, instance, condition); err != nil {
-				return ctrl.Result{}, err
-			}
+		if err := r.Create(ctx, eps); err != nil {
 			return ctrl.Result{}, err
 		}
 		instance.Status.Phase = modelv1alpha1.ModelAdapterRunning
-	} else {
-		// Existing EndpointSlice Found. Check if the Pod IP is already in the EndpointSlice
-		podIP := pod.Status.PodIP
-		alreadyExists := false
-		for _, endpoint := range found.Endpoints {
-			for _, address := range endpoint.Addresses {
-				if address == podIP {
-					alreadyExists = true
-					break
-				}
-			}
-			if alreadyExists {
-				break
-			}
-		}
-
-		// Append the Pod IP to the EndpointSlice if it doesn't exist
-		if !alreadyExists {
-			// TODO: come back when we start to support multi-instance.
-			//found.Endpoints = append(found.Endpoints, discoveryv1.Endpoint{
-			//	Addresses: []string{podIP},
-			//})
-
-			// override the endpoint with only one pod id.
-			// TODO: We need to refactor the logic once we start to support multi instances later
-			found.Endpoints = []discoveryv1.Endpoint{
-				{
-					Addresses: []string{podIP},
-				},
-			}
-
-			if err := r.Update(ctx, found); err != nil {
-				klog.ErrorS(err, "Failed to update EndpointSlice", "EndpointSlice", found.Name)
-				return ctrl.Result{}, err
-			}
-			instance.Status.Phase = modelv1alpha1.ModelAdapterRunning
-			klog.InfoS("Successfully updated EndpointSlice", "EndpointSlice", found.Name)
-		} else {
-			// pod has been deleted, and we should remove the pod name from the list
-			if pod.DeletionTimestamp != nil {
-				var updatedEndpoints []discoveryv1.Endpoint
-				podIP := pod.Status.PodIP
-
-				for _, endpoint := range found.Endpoints {
-					shouldRemove := false
-					var newAddresses []string
-
-					for _, address := range endpoint.Addresses {
-						if address == podIP {
-							shouldRemove = true
-						} else {
-							newAddresses = append(newAddresses, address)
-						}
-					}
-
-					if !shouldRemove || len(newAddresses) > 0 {
-						endpoint.Addresses = newAddresses
-						updatedEndpoints = append(updatedEndpoints, endpoint)
-					}
-				}
-
-				found.Endpoints = updatedEndpoints
-				if err := r.Update(ctx, found); err != nil {
-					klog.ErrorS(err, "Failed to update EndpointSlice after removing PodIP", "EndpointSlice", found.Name)
-					return ctrl.Result{}, err
-				}
-
-				instance.Status.Phase = modelv1alpha1.ModelAdapterFailed
-				klog.InfoS("Successfully removed Pod IP from EndpointSlice", "PodIP", podIP, "EndpointSlice", found.Name)
-			} else {
-				klog.V(4).InfoS("Pod IP already exists in EndpointSlice", "PodName", pod.Name, "PodIP", podIP)
-				instance.Status.Phase = modelv1alpha1.ModelAdapterRunning
-			}
-		}
+		return ctrl.Result{}, nil
 	}
 
+	endpoints := make([]discoveryv1.Endpoint, 0, len(podList))
+	for _, p := range podList {
+		endpoints = append(endpoints, discoveryv1.Endpoint{Addresses: []string{p.Status.PodIP}})
+	}
+	found.Endpoints = endpoints
+	if err := r.Update(ctx, found); err != nil {
+		return ctrl.Result{}, err
+	}
+	instance.Status.Phase = modelv1alpha1.ModelAdapterRunning
 	return ctrl.Result{}, nil
 }
 

--- a/pkg/controller/modeladapter/resources.go
+++ b/pkg/controller/modeladapter/resources.go
@@ -25,15 +25,16 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func buildModelAdapterEndpointSlice(instance *modelv1alpha1.ModelAdapter, pod *corev1.Pod) *discoveryv1.EndpointSlice {
+func buildModelAdapterEndpointSlice(instance *modelv1alpha1.ModelAdapter, pods []corev1.Pod) *discoveryv1.EndpointSlice {
 	serviceLabels := map[string]string{
 		"kubernetes.io/service-name": instance.Name,
 	}
 
-	addresses := []discoveryv1.Endpoint{
-		{
+	addresses := make([]discoveryv1.Endpoint, 0, len(pods))
+	for _, pod := range pods {
+		addresses = append(addresses, discoveryv1.Endpoint{
 			Addresses: []string{pod.Status.PodIP},
-		},
+		})
 	}
 
 	ports := []discoveryv1.EndpointPort{

--- a/pkg/controller/modeladapter/resources_test.go
+++ b/pkg/controller/modeladapter/resources_test.go
@@ -36,15 +36,16 @@ func TestBuildModelAdapterEndpointSlice(t *testing.T) {
 		},
 	}
 
-	// Mock input for Pod
-	pod := &corev1.Pod{
+	// Mock input for Pods
+	pod := corev1.Pod{
 		Status: corev1.PodStatus{
 			PodIP: "192.168.1.1",
 		},
 	}
+	pods := []corev1.Pod{pod}
 
 	// Call the function to test
-	endpointSlice := buildModelAdapterEndpointSlice(instance, pod)
+	endpointSlice := buildModelAdapterEndpointSlice(instance, pods)
 
 	// Check EndpointSlice metadata
 	assert.Equal(t, "test-instance", endpointSlice.Name)


### PR DESCRIPTION
## Summary
- allow controller to sync adapter instances with all active pods
- load adapter on each pod
- update EndpointSlice with all pod IPs
- adjust resources and tests for multi-pod support

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.25.0.3:8080: connect: no route to host)*